### PR TITLE
Add demo of using Plug.Builder to handle requests as pipelines

### DIFF
--- a/lib/scout/web/controllers/survey_show_plug.ex
+++ b/lib/scout/web/controllers/survey_show_plug.ex
@@ -1,0 +1,63 @@
+defmodule Scout.Web.SurveyShowPlug do
+  use Plug.Builder
+  alias Plug.Conn
+  import Plug.Conn, only: [put_resp_content_type: 2]
+
+  plug :put_resp_content_type, "application/json"
+  plug :validate
+  plug :authorize
+  plug :query
+  plug :respond
+
+  @doc "Function plug to validate a GET /surveys/:id request"
+  def validate(conn = %Conn{params: %{"id" => id}}, _opts) do
+    with [] <- Scout.Util.ValidationHelpers.validate_uuid(:id, id) do
+      Conn.assign conn, :survey_id, id
+    else
+      [id: error_msg] ->
+        conn
+        |> Conn.send_resp(422, Poison.encode! %{errors: %{id: [error_msg]}})
+        |> Conn.halt()
+    end
+  end
+
+  @doc "Function plug to authorize the current user for accessing GET /surveys/:id request"
+  def authorize(conn = %Conn{assigns: %{survey_id: _id}}, _opts) do
+    with ["123"] <- Conn.get_req_header(conn, "authorization") do
+      Conn.assign conn, :user_id, 123
+    else
+      [] ->
+        conn
+        |> Conn.send_resp(401, Poison.encode! %{errors: %{user: ["Unauthorized"]}})
+        |> Conn.halt()
+      _ ->
+        conn
+        |> Conn.send_resp(403, Poison.encode! %{errors: %{user: ["Forbidden"]}})
+        |> Conn.halt()
+    end
+  end
+
+  @doc "Function plug to load a survey by ID from the database"
+  def query(conn = %Conn{assigns: %{survey_id: id}}, _opts) do
+    with {:ok, survey} <- Scout.Core.find_survey_by_id(id) do
+      Conn.assign conn, :survey, survey
+    else
+      {:error, reason} ->
+        conn
+        |> Conn.send_resp(404, Poison.encode! %{errors: reason})
+        |> Conn.halt()
+    end
+  end
+
+  @doc "Function plug to serialize a Survey to JSON and respond"
+  def respond(conn = %Conn{assigns: %{survey: survey}}, _opts) do
+    response = %{
+      name: survey.name,
+      state: survey.state,
+      started_at: survey.started_at,
+      finished_at: survey.finished_at,
+      response_count: survey.response_count
+    }
+    Conn.send_resp(conn, 200, Poison.encode!(response))
+  end
+end

--- a/lib/scout/web/router.ex
+++ b/lib/scout/web/router.ex
@@ -9,5 +9,6 @@ defmodule Scout.Web.Router do
     pipe_through :api
 
     post "/surveys", SurveyController, :create
+    get "/surveys/:id", SurveyShowPlug, :show, as: :survey
   end
 end

--- a/test/web/controllers/survey_show_plug_test.exs
+++ b/test/web/controllers/survey_show_plug_test.exs
@@ -1,0 +1,62 @@
+defmodule Scout.Web.SurveyShowPlugTest do
+  use Scout.Web.ConnCase, async: true
+
+  setup do
+    survey = %Scout.Survey{
+      owner_id: Ecto.UUID.generate(),
+      name: "hello"
+    }
+    %{survey: Scout.Repo.insert!(survey)}
+  end
+
+  test "Show with invalid survey ID is 422", %{conn: conn} do
+    conn = get(conn, survey_path(conn, :show, "not-a-uuid"))
+    assert json_response(conn, 422) == %{
+      "errors" => %{"id" => ["Is not a valid UUID"]}
+    }
+  end
+
+  test "Show with missing auth header is 401", %{conn: conn, survey: survey} do
+    conn = get(conn, survey_path(conn, :show, survey.id))
+    assert json_response(conn, 401) == %{
+      "errors" => %{"user" => ["Unauthorized"]}
+    }
+  end
+
+  test "Show with invalid auth header is 403", %{conn: conn, survey: survey} do
+    conn =
+      conn
+      |> put_req_header("authorization", "the-wront-value")
+      |> get(survey_path(conn, :show, survey.id))
+
+    assert json_response(conn, 403) == %{
+      "errors" => %{"user" => ["Forbidden"]}
+    }
+  end
+
+  test "Show with unknown survey ID is 404", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "123")
+      |> get(survey_path(conn, :show, Ecto.UUID.generate()))
+
+    assert json_response(conn, 404) == %{
+      "errors" => %{"id" => "Survey not found"}
+    }
+  end
+
+  test "Show a survey", %{conn: conn, survey: survey} do
+    conn =
+      conn
+      |> put_req_header("authorization", "123")
+      |> get(survey_path(conn, :show, survey.id))
+
+    assert json_response(conn, 200) == %{
+      "finished_at" => nil,
+      "name" => "hello",
+      "response_count" => 0,
+      "started_at" => nil,
+      "state" => "design"
+    }
+  end
+end


### PR DESCRIPTION
The default approach in Phoenix is to route requests to a Controller action.

Often a controller action has to perform a sequence of steps, each of which can fail the request:

* Validating the request -> Fails with 422 
* Authorizing the request -> Fails with 401/403
* Querying data -> Fails with 404
* Updating data -> Fails with 422
* Respond -> Should succeed with 2xx if all previous steps succeed

This PR demonstrates a way to express each step as a function plug, which are then composed using `Plug.Builder` and the `plug` macro:

```elixir
  use Plug.Builder

  plug :put_resp_content_type, "application/json"
  plug :validate
  plug :authorize
  plug :query
  plug :respond
```

To integrate cleanly with the phoenix router, the route needs to be declared with an action and a name to use for the generated helper:

```elixir
 get "/surveys/:id", SurveyShowPlug, :show, as: :survey
```

Running `mix phx.routes`  shows that the router helper is being generated:

```
survey_path  POST  /api/surveys      Scout.Web.SurveyController :create
survey_path  GET   /api/surveys/:id  Scout.Web.SurveyShowPlug :show
```