### PR TITLE
Alpine based docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ erl_crash.dump
 /config/*.secret.exs
 releases/
 .mix/
+
+# IDE files
+.elixir_ls/

--- a/README.md
+++ b/README.md
@@ -11,25 +11,26 @@ Prerequisites: Docker (tested with Docker for Mac)
 Fetch dependencies:
 
 ```
-./bin/deps
+./bin/mix deps.get
 ```
 
 Compile source code:
 
 ```
-./bin/compile
+./bin/mix compile
 ```
 
 Run unit tests:
 
 ```
-./bin/test
+./bin/mix test
 ```
 
 Run database migrations:
 
 ```
-./bin/dbmigrate
+MIX_ENV=dev ./bin/dbmigrate
+MIX_ENV=prod ./bin/dbmigrate
 ```
 
 Start iex console:
@@ -790,7 +791,7 @@ commit []
    survey: #Ecto.Association.NotLoaded<association :survey is not loaded>,
    inserted_at: %DateTime{...},
    updated_at: %DateTime{...}}],
- inserted_at: %DateTime{...},  
+ inserted_at: %DateTime{...},
  updated_at: %DateTime{...}}
 }
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-bin/mix compile

--- a/bin/deps
+++ b/bin/deps
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-bin/mix do local.hex --force, local.rebar --force, deps.get

--- a/bin/dev
+++ b/bin/dev
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-MIX_ENV=dev docker-compose -f docker/docker-compose.yml run --rm -p 4000:4000 elixir mix phx.server
+MIX_ENV=dev docker-compose -f docker/docker-compose.yml run --rm --service-ports elixir mix phx.server

--- a/bin/release
+++ b/bin/release
@@ -2,10 +2,4 @@
 
 set -euo pipefail
 
-MIX_ENV=${MIX_ENV:-prod}
-
-MIX_ENV=${MIX_ENV} bin/mix release
-
-if [ $MIX_ENV = "prod" ]; then
-  docker build -f docker/Dockerfile -t mbuhot/scout .
-fi
+docker-compose -f docker/docker-compose.yml build scout

--- a/bin/scout
+++ b/bin/scout
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-docker-compose -f docker/docker-compose.yml run --service-ports scout $@
+docker-compose -f docker/docker-compose.yml run --rm --service-ports scout $@

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-MIX_ENV=test bin/mix do ecto.create --quiet, ecto.migrate, test

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,7 +16,8 @@ use Mix.Config
 config :scout, Scout.Web.Endpoint,
   url: [host: "${HOST}", port: "${PORT}"],
   on_init: {Scout.Web.Endpoint, :load_from_system_env, []},
-  server: true
+  server: true,
+  secret_key_base: "${SECRET_KEY_BASE}"
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,48 @@
-FROM everydayhero/ubuntu:16.04
+# -------------
+# Build Stage
+#--------------
 
-ENV REPLACE_OS_VARS true
-ENV PORT 8080
-EXPOSE 8080
+# Create a basic elixir/node build environment
+FROM elixir:1.5-alpine as build
+RUN apk add --update nodejs nodejs-npm
+RUN mix local.hex --force
+RUN mix local.rebar --force
 
-ADD "releases/0.0.1/scout.tar.gz" /app
-RUN ln -s /app/releases/0.0.1/scout.sh /app/scout.sh
+# /build for source code, and /rel for extracted release archive
+RUN mkdir /build /rel
 
+# Fetch and build dependencies
+WORKDIR /build
+ENV MIX_ENV=prod
+COPY mix.* /build/
+RUN mix deps.get
+COPY config /build/config
+RUN mix deps.compile
+
+# Copy sources into image
+COPY lib /build/lib
+COPY priv /build/priv
+COPY rel /build/rel
+
+# Build elixir OTP release, extracted to /rel
+RUN mix phx.digest
+RUN mix release
+RUN tar -xvzf _build/prod/rel/*/releases/*/*.tar.gz -C /rel
+
+
+#-----------------
+# Deploy Stage
+#-----------------
+
+# Vanilla alpine base, ERTS is bundled with release
+FROM alpine
+
+# install required system dependencies
+RUN apk add --no-cache bash openssl ncurses-libs
+
+# Add the release binaries
+COPY --from=build /rel /app
+
+# Run app in foreground
 WORKDIR /app
-CMD ./scout.sh foreground
+CMD bin/scout foreground

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,5 @@
+FROM elixir:1.5-alpine
+RUN mix do local.hex --force
+RUN mix local.rebar --force
+RUN apk add --update nodejs nodejs-npm
+CMD iex

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,8 @@
 version: '2.1'
 
-volumes:
-  build:
-    driver: local
-
 services:
   postgres:
-    image: postgres:9.5
+    image: postgres:alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
@@ -17,16 +13,16 @@ services:
       retries: 3
 
   elixir:
-    image: elixir:1.5
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.dev
     environment:
       - MIX_ENV
       - DATABASE_URL
-      - COOKIE
+    ports:
+      - "4000:4000"
     volumes:
       - ..:/app
-      - ../.mix:/root/.mix
-      - build:/app/_build
-      - ../releases:/app/_build/prod/rel/scout/releases
     working_dir: /app
     depends_on:
       postgres:
@@ -35,14 +31,21 @@ services:
       - postgres
 
   scout:
-    image: mbuhot/scout
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: everydayhero/scout:latest
     environment:
       - DATABASE_URL=postgres://postgres:password@postgres/scout
       - HOST=scout.com
+      - PORT=8080
+      - REPLACE_OS_VARS=true
+      - SECRET_KEY_BASE=SUPER_SECRET_KEY_BASE
+      - COOKIE=SUPER_SECRET_COOKIE
+    ports:
+      - "8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
     links:
       - postgres
-    ports:
-      - 8080:8080

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -14,7 +14,7 @@ end
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: System.get_env("COOKIE") |> String.to_atom()
+  set cookie: "${COOKIE}"
 end
 
 release :scout do


### PR DESCRIPTION
This PR further reduces the size of the docker images to ~52 Mb.

The release is compiled using `elixir:1.5.2-alpine` with the ERTS bundled.
The deployed docker file is built from a base `alpine:3.6` image with `openssl` and `ncurses-libs` packages added to get the phoenix server running.


