### PR TITLE
Add basic command macro

### DIFF
--- a/lib/scout/commands/add_survey_response.ex
+++ b/lib/scout/commands/add_survey_response.ex
@@ -5,10 +5,10 @@ defmodule Scout.Commands.AddSurveyResponse do
   alias Scout.Util.ValidationHelpers
   alias Scout.{Response, Survey}
 
-  cmd do
-    attr :survey_id, :binary_id, [:required, {:custom, &ValidationHelpers.validate_uuid/2}]
-    attr :respondant_email, :string, [:required, {:format, ~r/@/}]
-    attr :answers, {:array, :string}, [:required]
+  command do
+    attr :survey_id, :binary_id, required: true, validate: &ValidationHelpers.validate_uuid/2
+    attr :respondant_email, :string, required: true, format: ~r/@/
+    attr :answers, {:array, :string}, required: true
   end
 
   @doc """

--- a/lib/scout/commands/add_survey_response.ex
+++ b/lib/scout/commands/add_survey_response.ex
@@ -1,4 +1,4 @@
-  defmodule Scout.Commands.AddSurveyResponse do
+defmodule Scout.Commands.AddSurveyResponse do
   use Ecto.Schema
 
   alias Ecto.{Changeset, Multi}
@@ -44,6 +44,5 @@
     Multi.new()
     |> Multi.insert(:response, Response.insert_changeset(cmd))
     |> Multi.update(:survey, Survey.increment_response_count_changeset(survey))
-    # |> Multi.update_all(:survey2, Survey.increment_response_count_query(id: survey.id), [])
   end
 end

--- a/lib/scout/commands/add_survey_response.ex
+++ b/lib/scout/commands/add_survey_response.ex
@@ -1,37 +1,14 @@
 defmodule Scout.Commands.AddSurveyResponse do
-  use Ecto.Schema
+  use Scout.Commands.Command
 
-  alias Ecto.{Changeset, Multi}
   alias Scout.Commands.AddSurveyResponse
   alias Scout.Util.ValidationHelpers
   alias Scout.{Response, Survey}
 
-  @primary_key false
-  embedded_schema do
-    field :survey_id, :binary_id
-    field :respondant_email, :string
-    field :answers, {:array, :string}
-  end
-
-  @doc """
-  Casts and validates params to build an `AddSurveyResponse` struct.
-
-  Returns {:ok, %AddSurveyResponse{}} on success, {:error, %Changeset{}} otherwise.
-  """
-  def new(params) do
-    with cs = %{valid?: true} <- validate(params) do
-      {:ok, Changeset.apply_changes(cs)}
-    else
-      changeset -> {:error, changeset}
-    end
-  end
-
-  defp validate(params) do
-    %AddSurveyResponse{}
-    |> Changeset.cast(params, [:survey_id, :respondant_email, :answers])
-    |> Changeset.validate_required([:survey_id, :respondant_email, :answers])
-    |> Changeset.validate_change(:survey_id, &ValidationHelpers.validate_uuid/2)
-    |> Changeset.validate_format(:respondant_email, ~r/@/)
+  cmd do
+    attr :survey_id, :binary_id, [:required, {:custom, &ValidationHelpers.validate_uuid/2}]
+    attr :respondant_email, :string, [:required, {:format, ~r/@/}]
+    attr :answers, {:array, :string}, [:required]
   end
 
   @doc """

--- a/lib/scout/commands/command.ex
+++ b/lib/scout/commands/command.ex
@@ -78,11 +78,13 @@ defmodule Scout.Commands.Command do
     } = Macro.postwalk(attributes, {[], []}, &attribute_visitor/2)
 
     quote do
+      @type t :: %__MODULE__{}
       @primary_key false
       embedded_schema do
         unquote(fields_ast)
       end
 
+      @spec new(Enumerable.t) :: {:ok, t} | {:error, Changeset.t}
       def new(params) do
         with changeset = %{valid?: true} <- validate(params) do
           {:ok, Changeset.apply_changes(changeset)}
@@ -91,6 +93,7 @@ defmodule Scout.Commands.Command do
         end
       end
 
+      @spec validate(Enumerable.t) :: Changeset.t
       defp validate(params) do
         %__MODULE__{}
         |> Changeset.cast(Map.new(params), unquote(field_names))

--- a/lib/scout/commands/command.ex
+++ b/lib/scout/commands/command.ex
@@ -1,0 +1,100 @@
+defmodule Scout.Commands.Command do
+  alias Ecto.Changeset
+
+  defmacro __using__(_opts) do
+    quote do
+      use Ecto.Schema
+      import unquote(__MODULE__)
+      alias Ecto.{Changeset, Multi}
+    end
+  end
+
+  defp validation_visitor(node = {:custom, args}, validators) do
+    validation_ast = quote do
+      custom_validation_func = unquote(args)
+      fn
+        (changeset, prop) -> Changeset.validate_change(changeset, prop, custom_validation_func)
+      end
+    end
+
+    {node, [validation_ast | validators]}
+  end
+  defp validation_visitor(node = {:format, args}, validators) do
+    validation_ast = quote do
+      fn
+        (changeset, prop) -> Changeset.validate_format(changeset, prop, unquote(args))
+      end
+    end
+
+    {node, [validation_ast | validators]}
+  end
+  defp validation_visitor(node = {:length, args}, validators) do
+    validation_ast = quote do
+      fn
+        (changeset, prop) -> Changeset.validate_length(changeset, prop, unquote(args))
+      end
+    end
+
+    {node, [validation_ast | validators]}
+  end
+  defp validation_visitor(node = :required, validators) do
+    validation_ast = quote do
+      fn
+        (changeset, prop) -> Changeset.validate_required(changeset, prop)
+      end
+    end
+
+    {node, [validation_ast | validators]}
+  end
+  defp validation_visitor(node, validators), do: {node, validators}
+
+  defp attribute_visitor({:attr, _meta, [name, type, declared_validations]}, {field_names, validation_funcs}) do
+    {_ast, validators_for_prop} = Macro.postwalk(declared_validations, [], &validation_visitor/2)
+
+    validation_func_ast = quote do
+      fn changeset ->
+        Enum.reduce(
+          unquote(validators_for_prop),
+          changeset,
+          fn vfp, cs ->
+            vfp.(cs, unquote(name))
+          end
+        )
+      end
+    end
+    field_ast = quote do
+      field unquote(name), unquote(type)
+    end
+
+    {field_ast, {[name | field_names], [validation_func_ast | validation_funcs]}}
+  end
+  defp attribute_visitor(node, validation_funcs), do: {node, validation_funcs}
+
+  defmacro cmd(do: attributes) do
+    {
+      fields_ast,
+      {field_names, validation_asts}
+    } = Macro.postwalk(attributes, {[], []}, &attribute_visitor/2)
+
+    quote do
+      @primary_key false
+      embedded_schema do
+        unquote(fields_ast)
+      end
+
+      def new(params) do
+        with cs = %{valid?: true} <- validate(params) do
+          {:ok, Changeset.apply_changes(cs)}
+        else
+          changeset -> {:error, changeset}
+        end
+      end
+
+      defp validate(params) do
+        %__MODULE__{}
+        |> Changeset.cast(params, unquote(field_names))
+        |> Scout.Util.ValidationHelpers.validate_all(unquote(validation_asts))
+      end
+    end
+  end
+end

--- a/lib/scout/core/response.ex
+++ b/lib/scout/core/response.ex
@@ -1,6 +1,6 @@
 defmodule Scout.Response do
   use Ecto.Schema
-  
+
   alias Ecto.Changeset
   alias Scout.Response
   alias Scout.Commands.AddSurveyResponse

--- a/lib/scout/util/validation_helpers.ex
+++ b/lib/scout/util/validation_helpers.ex
@@ -5,4 +5,8 @@ defmodule Scout.Util.ValidationHelpers do
       {:ok, _} -> []
     end
   end
+
+  def validate_all(changeset, validation_funcs) when is_list(validation_funcs) do
+    Enum.reduce(validation_funcs, changeset, fn (validator, cs) -> validator.(cs) end)
+  end
 end

--- a/test/cmd_test.exs
+++ b/test/cmd_test.exs
@@ -1,0 +1,97 @@
+defmodule Scout.Commands.Command.Test do
+  use Scout.DataCase, async: true
+  alias Scout.Commands.DummyCommand
+
+  describe "Declared command" do
+    test "can be newed" do
+      {:ok, dummy_command} = DummyCommand.new(
+        %{
+          name: "name",
+          desc: "desc",
+          email: "test@test.com",
+          color: "red"
+        }
+      )
+
+      assert %DummyCommand{
+        name: "name",
+        desc: "desc",
+        email: "test@test.com",
+        color: "red"
+      } == dummy_command
+    end
+
+    test "validates required" do
+      {:error, %{errors: errors}}  = DummyCommand.new(
+        %{
+          email: "test@test.com",
+          color: "red"
+        }
+      )
+
+      assert [
+        name: {"can't be blank",
+          [
+            validation: :required
+          ]
+        },
+        desc: {"can't be blank",
+          [
+            validation: :required
+          ]
+        }
+      ] == errors
+    end
+
+    test "validates length" do
+      {:error, %{errors: errors}}  = DummyCommand.new(
+        %{
+          name: "name",
+          desc: ".",
+          email: "test@test.com",
+          color: "red"
+        }
+      )
+
+      assert [
+        desc: {
+          "should be at least %{count} character(s)",
+          [count: 2, validation: :length, min: 2]
+        }
+      ] == errors
+    end
+
+    test "validates format" do
+      {:error, %{errors: errors}}  = DummyCommand.new(
+        %{
+          name: "name",
+          desc: "desc",
+          email: ".",
+          color: "red"
+        }
+      )
+
+      assert [
+        email: {
+          "has invalid format",
+          [validation: :format]
+        }
+      ] == errors
+    end
+
+    test "validates custom" do
+      {:error, %{errors: errors}}  = DummyCommand.new(
+        %{
+          name: "name",
+          desc: "desc",
+          email: "test@test.com",
+          color: "blue"
+        }
+      )
+
+      assert [
+        color: { "is not red", [] }
+      ] == errors
+    end
+  end
+end

--- a/test/support/dummy_command.ex
+++ b/test/support/dummy_command.ex
@@ -1,11 +1,11 @@
 defmodule Scout.Commands.DummyCommand do
   use Scout.Commands.Command
 
-  cmd do
-    attr :name, :string, [:required]
-    attr :desc, :string, [:required, {:length, min: 2}]
-    attr :color, :string, [{:custom, fn f, v -> validate_red(f, v) end}]
-    attr :email, :string, [{:format, ~r/@/}]
+  command do
+    attr :name, :string, required: true
+    attr :desc, :string, required: true, length: [min: 2]
+    attr :color, :string, validate: fn f, v -> validate_red(f, v) end
+    attr :email, :string, format: ~r/@/
   end
 
   def validate_red(_field, "red"), do: []

--- a/test/support/dummy_command.ex
+++ b/test/support/dummy_command.ex
@@ -1,0 +1,13 @@
+defmodule Scout.Commands.DummyCommand do
+  use Scout.Commands.Command
+
+  cmd do
+    attr :name, :string, [:required]
+    attr :desc, :string, [:required, {:length, min: 2}]
+    attr :color, :string, [{:custom, fn f, v -> validate_red(f, v) end}]
+    attr :email, :string, [{:format, ~r/@/}]
+  end
+
+  def validate_red(_field, "red"), do: []
+  def validate_red(field, _), do: [{field, "is not red"}]
+end


### PR DESCRIPTION
This PR introduces a command macro that aims to take away some of the boiler plate of creating commands. It does not yet support `embeds_many`.