### PR TITLE
Speed up builds with native _build volume

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '2.1'
 
+volumes:
+  build:
+    driver: local
+
 services:
   postgres:
     image: postgres:alpine
@@ -23,6 +27,7 @@ services:
       - "4000:4000"
     volumes:
       - ..:/app
+      - build:/app/_build
     working_dir: /app
     depends_on:
       postgres:


### PR DESCRIPTION
I suspect this is related to virus scanners used by everydayhero.
This reduces the build time for a complete download + compile from 2m 30s -> 1m 20s.